### PR TITLE
Only get response on GuzzleRequestException

### DIFF
--- a/src/Tamara/HttpClient/GuzzleHttpAdapter.php
+++ b/src/Tamara/HttpClient/GuzzleHttpAdapter.php
@@ -82,7 +82,7 @@ class GuzzleHttpAdapter implements ClientInterface
                 $exception->getMessage(),
                 $exception->getCode(),
                 $request,
-                $exception instanceof GuzzleException ? $exception->getResponse() : null,
+                $exception instanceof GuzzleRequestException ? $exception->getResponse() : null,
                 $exception->getPrevious()
             );
         }


### PR DESCRIPTION
some guzzle exceptions like `ConnectException` don't have a response, which results in an error: `Call to undefined method GuzzleHttp\Exception\ConnectException::getResponse()`

reference: https://github.com/guzzle/guzzle/blob/de6f1e58e735754b888649495ed4cb9ae3b19589/src/Exception/ConnectException.php#L11