### PR TITLE
upgrade firebase/php-jwt to  v6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/log": "^1.0",
     "ext-json": "*",
     "symfony/http-foundation": ">=4.1",
-    "firebase/php-jwt": "^5.1",
+    "firebase/php-jwt": "^6.1",
     "nyholm/psr7": "^1.3",
     "kriswallsmith/buzz": "^1.2|^0.16",
     "guzzlehttp/guzzle": ">=6.0"

--- a/src/Tamara/Notification/Authenticator.php
+++ b/src/Tamara/Notification/Authenticator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tamara\Notification;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Symfony\Component\HttpFoundation\Request;
 use Tamara\Notification\Exception\ForbiddenException;
 use Throwable;
@@ -62,6 +63,6 @@ class Authenticator
      */
     protected function decode(string $token)
     {
-        return JWT::decode($token, $this->tokenKey, ['HS256']);
+        return JWT::decode($token, new Key($this->tokenKey, 'HS256'));
     }
 }


### PR DESCRIPTION
I am using a package that requires `firebase/php-jwt:^6.1` and I have your package conflicted with it , so I am proposing this solution for me and for anyone who might be in the same situation 

PS: the changes were according to the official docs
https://github.com/firebase/php-jwt/releases/tag/v6.0.0