### PR TITLE
fix: add null guard for status field in parse()

### DIFF
--- a/src/Tamara/Response/Order/GetOrderByReferenceIdResponse.php
+++ b/src/Tamara/Response/Order/GetOrderByReferenceIdResponse.php
@@ -258,7 +258,7 @@ class GetOrderByReferenceIdResponse extends ClientResponse
         $this->orderReferenceId = $responseData[self::ORDER_REFERENCE_ID];
         $this->orderNumber = $responseData[self::ORDER_NUMBER] ?? $this->orderReferenceId;
         $this->consumer = Consumer::fromArray($responseData[self::CONSUMER]);
-        $this->status = $responseData[self::STATUS];
+        $this->status = $responseData[self::STATUS] ?? '';
         $this->billingAddress = is_array($responseData[self::BILLING_ADDRESS]) ? Address::fromArray($responseData[self::BILLING_ADDRESS]) : null;
         $this->shippingAddress = Address::fromArray($responseData[self::SHIPPING_ADDRESS]);
         $this->paymentType = $responseData[self::PAYMENT_TYPE] ?? '';


### PR DESCRIPTION
### Problem                                                                     
                                                                                 
 When GetOrderByReferenceIdResponse::getStatus() is called and the Tamara API    
 response omits the status field, PHP throws a fatal TypeError:                  
                                                                                 
 ```                                                                             
   TypeError: Tamara\Response\Order\GetOrderByReferenceIdResponse::getStatus():  
   Return value must be of type string, null returned                            
 ```                                                                             
                                                                                 
 This happens because parse() assigns $responseData['status'] directly with no   
 null fallback, yet getStatus() declares a native : string return type. When the 
 API returns a successful HTTP response without a status key, $this->status is   
 null, and PHP enforces the return type at the boundary — crashing the caller.   
                                                                                 
 ### Root Cause                                                                  
                                                                                 
 In GetOrderByReferenceIdResponse::parse(), the status field is the only string  
 field assigned without a null guard:                                            
                                                                                 
 ```php                                                                          
   $this->status          = $responseData[self::STATUS];            // ❌        
 unguarded                                                                       
   $this->paymentType     = $responseData[self::PAYMENT_TYPE] ?? ''; // ✅       
 guarded                                                                         
   $this->settlementStatus = $responseData[self::SETTLEMENT_STATUS] ?? ''; // ✅ 
 guarded                                                                         
 ```                                                                             
                                                                                 
 ### Fix                                                                         
                                                                                 
 Added ?? '' to the status assignment so it matches the existing pattern:        
                                                                                 
 ```php                                                                          
   $this->status = $responseData[self::STATUS] ?? '';                            
 ```                                                                             
                                                                                 
 An empty string is a safe default — any caller comparing against 'authorised'   
 or 'approved' will correctly treat it as an unpaid/non-finalized order.         
                                                                                 
 ### Affected Versions                                                           
                                                                                 
 - 2.0.x — affected (fix on branch fix/getstatus-null-guard-v2)                  
 - 3.0.x — affected (fix on master)                                              
                                                                                 
 ### No Breaking Changes                                                         
                                                                                 
 - Return type remains : string — no signature change                            
 - Behavior is identical for valid responses where status is present             
 - Callers checking === 'authorised' on a missing status now get false instead   
   of a crash                                                                    
